### PR TITLE
Use a macro to simplify filling in Creatable trait.

### DIFF
--- a/src/plasma/audio/sound_buffer.rs
+++ b/src/plasma/audio/sound_buffer.rs
@@ -18,8 +18,8 @@ use std::io::{BufRead, Result, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
-use crate::plasma::{Key, Creatable, StreamRead, StreamWrite};
-use crate::plasma::creatable::ClassID;
+use crate::derive_creatable;
+use crate::plasma::{Key, StreamRead, StreamWrite};
 use crate::plasma::safe_string::{read_safe_str, write_safe_str, StringFormat};
 
 pub struct SoundBuffer {
@@ -29,6 +29,8 @@ pub struct SoundBuffer {
     file_name: String,
     wav_header: WavHeader,
 }
+
+derive_creatable!(SoundBuffer);
 
 struct WavHeader {
     format_tag: u16,
@@ -61,12 +63,6 @@ impl SoundBuffer {
     }
 
     pub fn file_name(&self) -> &String { &self.file_name }
-}
-
-impl Creatable for SoundBuffer {
-    fn class_id(&self) -> u16 { ClassID::SoundBuffer as u16 }
-    fn static_class_id() -> u16 { ClassID::SoundBuffer as u16 }
-    fn as_creatable(&self) -> &dyn Creatable { self }
 }
 
 impl StreamRead for SoundBuffer {

--- a/src/plasma/creatable.rs
+++ b/src/plasma/creatable.rs
@@ -113,3 +113,23 @@ pub(crate) enum ClassID {
 
     Nil = 0x8000,
 }
+
+#[macro_export]
+macro_rules! derive_creatable {
+    ($name:ident) => {
+        derive_creatable! { $name @lines[] }
+    };
+    ($name:ident, Message) => {
+        derive_creatable! { $name @lines[
+            fn as_message(self: Box<Self>) -> Option<Box<dyn MessageInterface>> { Some(self) }
+        ] }
+    };
+    ($name:ident @lines[ $($lines:tt)* ]) => {
+        impl $crate::plasma::Creatable for $name {
+            fn class_id(&self) -> u16 { $crate::plasma::creatable::ClassID::$name as u16 }
+            fn static_class_id() -> u16 { $crate::plasma::creatable::ClassID::$name as u16 }
+            fn as_creatable(&self) -> &dyn $crate::plasma::Creatable { self }
+            $($lines)*
+        }
+    };
+}

--- a/src/plasma/messages/message_with_callbacks.rs
+++ b/src/plasma/messages/message_with_callbacks.rs
@@ -18,9 +18,8 @@ use std::io::{BufRead, Write, Result};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
-use crate::general_error;
-use crate::plasma::{Creatable, StreamRead, StreamWrite};
-use crate::plasma::creatable::ClassID;
+use crate::{general_error, derive_creatable};
+use crate::plasma::{StreamRead, StreamWrite};
 use crate::plasma::Factory;
 use super::{Message, MessageInterface};
 
@@ -29,15 +28,7 @@ pub struct MessageWithCallbacks {
     callbacks: Vec<Box<dyn MessageInterface>>,
 }
 
-impl Creatable for MessageWithCallbacks {
-    fn class_id(&self) -> u16 { ClassID::MessageWithCallbacks as u16 }
-    fn static_class_id() -> u16 { ClassID::MessageWithCallbacks as u16 }
-
-    fn as_creatable(&self) -> &dyn Creatable { self }
-    fn as_message(self: Box<Self>) -> Option<Box<dyn MessageInterface>> {
-        Some(self)
-    }
-}
+derive_creatable!(MessageWithCallbacks, Message);
 
 impl StreamRead for MessageWithCallbacks {
     fn stream_read<S>(stream: &mut S) -> Result<Self>

--- a/src/plasma/net_common/generic_value.rs
+++ b/src/plasma/net_common/generic_value.rs
@@ -20,9 +20,8 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 
-use crate::general_error;
-use crate::plasma::{Creatable, StreamRead, StreamWrite};
-use crate::plasma::creatable::ClassID;
+use crate::{general_error, derive_creatable};
+use crate::plasma::{StreamRead, StreamWrite};
 use crate::plasma::safe_string::{read_safe_str, write_safe_str, StringFormat};
 
 pub enum GenericType {
@@ -41,11 +40,7 @@ pub struct CreatableGenericValue {
     value: GenericType,
 }
 
-impl Creatable for CreatableGenericValue {
-    fn class_id(&self) -> u16 { ClassID::CreatableGenericValue as u16 }
-    fn static_class_id() -> u16 { ClassID::CreatableGenericValue as u16 }
-    fn as_creatable(&self) -> &dyn Creatable { self }
-}
+derive_creatable!(CreatableGenericValue);
 
 #[repr(u8)]
 #[derive(FromPrimitive)]


### PR DESCRIPTION
This could probably also be done with a derive() macro, but that's a bit more complicated (especially for supporting the various trait downcast functions)